### PR TITLE
Feature/2023q4/calculate pixel locations in sprite

### DIFF
--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -36,7 +36,7 @@ function update(stepTime) {
 	if (store.throttle)
 		sprite.update(stepTime);
 	else
-		sprite.skipToFrame(0);
+		sprite.skipToFrame(0, { end: true });
 }
 function draw() {
 	if (! store.display) return;

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -55,8 +55,9 @@ function draw() {
 		case 'bug': {
 			// see https://spicyyoghurt.com/tutorials/html5-javascript-game-development/images-and-sprite-animations
 			const SCALE = 4;
-			const OUTLINE = 0 * height;
-			const FILL = 1 * height;
+			const FRAME = sprite.framePx;
+			const OUTLINE = sprite.getLayerPx(0);
+			const FILL = sprite.getLayerPx(1);
 			const drawArea = [
 				store.x - (SCALE * width / 2),
 				store.y - (SCALE * height / 2),
@@ -72,7 +73,7 @@ function draw() {
 			helper.fillStyle = store.color;
 			helper.fillRect(0, 0, width, height);
 			helper.globalCompositeOperation = 'destination-in'; // see https://stackoverflow.com/questions/45706829/change-color-image-in-canvas
-			helper.drawImage(sprite.img, sprite.frameLocation, FILL, width, height, 0, 0, width, height);
+			helper.drawImage(sprite.img, FRAME, FILL, width, height, 0, 0, width, height);
 
 			// set rotation
 			display.translate(store.x, store.y);
@@ -82,7 +83,7 @@ function draw() {
 			display.drawImage(helper.canvas, ...drawArea);
 			// draw the outline
 			display.fillStyle = '#000000';
-			display.drawImage(sprite.img, sprite.frameLocation, OUTLINE, width, height, ...drawArea);
+			display.drawImage(sprite.img, FRAME, OUTLINE, width, height, ...drawArea);
 			// reset rotation (and everything else)
 			display.setTransform(1, 0, 0, 1, 0, 0);
 			break;

--- a/src/game/Sprite.js
+++ b/src/game/Sprite.js
@@ -350,8 +350,11 @@ export default class Sprite {
 	}
 	/**
 	 * @param {number} frame  The frame index to render.
+	 * @param {object} [options]
+	 * @param {boolean} [options.end=false]
+	 *   If true, will skip to the end of the given frame instead of the start.
 	 */
-	skipToFrame(frame) {
+	skipToFrame(frame, options) {
 		frame = parseInt(frame, 10);
 
 		if (Number.isNaN(frame) || frame < 0)
@@ -359,9 +362,14 @@ export default class Sprite {
 		if (frame > this.options.frames.length)
 			throw new SpriteError(`Frame ${frame} does not exist`);
 
+		options = Object.assign({
+			// defaults
+			end: false,
+		}, options);
+
 		// set animation to the start of the given frame
 		this.#frame = frame;
-		this.#frameTime = 0;
+		this.#frameTime = options.end ? this.#frameDuration - 1 : 0;
 	}
 	/**
 	 * Method to update the animation frame based on the time elapsed since the

--- a/src/game/Sprite.js
+++ b/src/game/Sprite.js
@@ -23,7 +23,9 @@ const ReadyState = {
  * @param {Sprite~throttle} [throttle]
  */
 export default class Sprite {
-	constructor(src, options) {
+	constructor(src, options, DEBUG=false) {
+		if (typeof DEBUG === 'boolean') this.DEBUG = DEBUG;
+
 		this.#setArchivalProps(src, options);
 		this.#setOptions(options);
 		this.#initAnimation();
@@ -34,6 +36,8 @@ export default class Sprite {
 	}
 
 
+	/** @var {boolean} */
+	static DEBUG = false;
 	static ReadyState = ReadyState;
 	static get DEFAULTS() {
 		return {
@@ -256,6 +260,8 @@ export default class Sprite {
 	}
 
 
+	/** @var {boolean} */
+	DEBUG = this.constructor.DEBUG;
 	/** @var {Image} */
 	img = asyncImage();
 	/** @var {object} */

--- a/src/game/Sprite.js
+++ b/src/game/Sprite.js
@@ -5,7 +5,13 @@ export class SpriteOutOfBoundsError extends SpriteError {}
 export class SpriteTypeError extends TypeError {}
 export class SpriteSrcTypeError extends SpriteTypeError {}
 
-const asyncImage = () => { const img = new Image(); img.decoding = 'async'; return img; };
+
+const asyncImage = () => {
+	const img = new Image();
+	img.decoding = 'async';
+
+	return img;
+};
 
 /** @enum {string}
   * @memberof Sprite */
@@ -215,7 +221,7 @@ export default class Sprite {
 			if (typeof value !== 'number'
 			||  Number.isNaN(value))
 				throw new SpriteOptionError(
-					`'${name}' must be a number (${JSON.stringify(value)})`,
+					`'${name}' option must be a number (${JSON.stringify(value)})`,
 				);
 		}
 

--- a/src/game/Sprite.js
+++ b/src/game/Sprite.js
@@ -321,17 +321,22 @@ export default class Sprite {
 	/** @var {object} */
 	options = Object.assign({}, this.constructor.DEFAULTS);
 
-	/** @var {string} */
-	get readyState() { return this.#readyState; }
-	/** @var {?object} */
-	get size() { return this.options.size; }
-	/** @var {number} */
+	/** The pixel location of the current frame in the img.
+	  * @readonly
+	  * @var {number} */
 	get frameLocation() {
 		return this.#hasAnimation
 			? this.options.frames[this.#frame] * this.options.size.width
 			: 0;
 	}
-	/** @var {?string} */
+	/** @readonly
+	  * @var {string} */
+	get readyState() { return this.#readyState; }
+	/** @readonly
+	  * @var {object} */
+	get size() { return this.options.size; }
+	/** @readonly
+	  * @var {?string} */
 	get src() { return this.#src; }
 
 

--- a/src/game/Sprite.js
+++ b/src/game/Sprite.js
@@ -332,6 +332,14 @@ export default class Sprite {
 	/**
 	 * @returns {Promise}
 	 */
+	load() {
+		if (this.readyState !== ReadyState.PENDING) return;
+
+		this.#load();
+	}
+	/**
+	 * @returns {Promise}
+	 */
 	ready() {
 		this.#ensureLoadPromise();
 

--- a/src/game/Sprite.js
+++ b/src/game/Sprite.js
@@ -162,14 +162,11 @@ export default class Sprite {
 	#setOptions(options) {
 		if (! options) return;
 
-		try {
-			options = this.#validateOptions(options);
-		}
-		catch (err) {
-			return console.warn(`${err.name}: ${err.message}`);
-		}
+		options = this.#validateOptions(options);
 
-		Object.assign(this.options, options);
+		// Assign only the supported options
+		Object.keys(this.constructor.DEFAULTS)
+			.forEach(option => this.options[option] = options[option]);
 	}
 	#setSrc(src) {
 		if (! src || src === this.#src) return;

--- a/src/game/Sprite.js
+++ b/src/game/Sprite.js
@@ -78,6 +78,8 @@ export default class Sprite {
 	#frameDuration = 0;
 	#frameTime = 0;
 	#hasAnimation = false;
+	#imgFrames = null;
+	#imgLayers = null;
 	#loadPromise = null;
 	#readyState = ReadyState.PENDING;
 
@@ -89,7 +91,13 @@ export default class Sprite {
 				this.img.onerror = reject;
 			});
 
-		this.#loadPromise.then(() => { this.#readyState = ReadyState.READY; });
+		this.#loadPromise
+			.then(() => {
+				this.#imgFrames = Math.ceil(this.img.width / this.options.size.width);
+				this.#imgLayers = Math.ceil(this.img.height / this.options.size.height);
+
+				this.#readyState = ReadyState.READY;
+			});
 	}
 	#initAnimation() {
 		this.#hasAnimation = (

--- a/src/game/Sprite.js
+++ b/src/game/Sprite.js
@@ -3,6 +3,16 @@ export class SpriteOptionError extends SpriteError {}
 
 const asyncImage = () => { const img = new Image(); img.decoding = 'async'; return img; };
 
+/** @enum {string}
+  * @memberof Sprite */
+const ReadyState = {
+	ERROR: 'error',
+	LOADING: 'loading',
+	PENDING: 'pending',
+	READY: 'ready',
+};
+
+
 /**
  * @param {string} src  The path to the sprite image file.
  * @param {Sprite~options} [options]
@@ -24,6 +34,7 @@ export default class Sprite {
 	}
 
 
+	static ReadyState = ReadyState;
 	static get DEFAULTS() {
 		return {
 			fps: 0,
@@ -64,7 +75,7 @@ export default class Sprite {
 	#frameTime = 0;
 	#hasAnimation = false;
 	#loadPromise = null;
-	#readyState = 'pending';
+	#readyState = ReadyState.PENDING;
 
 
 	#ensureLoadPromise() {
@@ -74,7 +85,7 @@ export default class Sprite {
 				this.img.onerror = reject;
 			});
 
-		this.#loadPromise.then(() => { this.#readyState = 'loaded'; });
+		this.#loadPromise.then(() => { this.#readyState = ReadyState.READY; });
 	}
 	#initAnimation() {
 		this.#hasAnimation = (
@@ -86,14 +97,14 @@ export default class Sprite {
 		this.#frameDuration = 1000 / this.options.fps;
 	}
 	#load() {
-		this.#readyState = 'loading';
 		this.#ensureLoadPromise();
 
+		this.#readyState = ReadyState.LOADING;
 		this.img.src = this.src;
 	}
 	#reset() {
 		this.#loadPromise = null;
-		this.#readyState = 'pending';
+		this.#readyState = ReadyState.PENDING;
 	}
 	#setArchivalProps(src, options) {
 		if (src)

--- a/src/game/Sprite.js
+++ b/src/game/Sprite.js
@@ -1,6 +1,7 @@
 export class SpriteError extends Error {}
 export class SpriteCancelLoadError extends SpriteError {}
 export class SpriteOptionError extends SpriteError {}
+export class SpriteOutOfBoundsError extends SpriteError {}
 
 const asyncImage = () => { const img = new Image(); img.decoding = 'async'; return img; };
 
@@ -357,10 +358,14 @@ export default class Sprite {
 	skipToFrame(frame, options) {
 		frame = parseInt(frame, 10);
 
-		if (Number.isNaN(frame) || frame < 0)
-			throw new SpriteError(`Invalid frame ${JSON.stringify(frame)}`);
-		if (frame > this.options.frames.length)
-			throw new SpriteError(`Frame ${frame} does not exist`);
+		if (Number.isNaN(frame))
+			throw new SpriteError(
+				`Invalid frame ${JSON.stringify(frame)}`,
+			);
+		if (frame < 0 || frame > this.options.frames.length)
+			throw new SpriteOutOfBoundsError(
+				`Frame ${JSON.stringify(frame)} does not exist`,
+			);
 
 		options = Object.assign({
 			// defaults
@@ -389,5 +394,11 @@ export default class Sprite {
 			this.#frameTime %= this.#frameDuration;
 			this.#frame = (this.#frame + 1) % frames.length;
 		}
+
+		if (this.DEBUG
+		&&  this.#frame > this.options.frames.length)
+			console.warn(new SpriteOutOfBoundsError(
+				`Frame ${JSON.stringify(this.#frame)} does not exist`,
+			).message);
 	}
 }


### PR DESCRIPTION
This moves the logic for animating an animated sprite into the Sprite class.  It also adds rudimentary support for layers in the Sprite class so that the game render logic only needs to track what frame and layer it's requesting.

The next step for this is to have the Sprite class cache (and possibly pre-render) each of its frames when the image loads.  The only logical thing to solve is how to specify the layers to the Sprite such that we can have the sprite colorized per-layer.  See issue #10 for details on that.