### PR TITLE
Feature/2023q4/slow mode for keyboard controls

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -6,30 +6,30 @@ import Joystick from '@/components/Joystick.vue';
 
 const store = inject('store');
 
-const Key = { 87: 'w', 65: 'a', 83: 's', 68: 'd' };
+const Key = { 87: 'w', 65: 'a', 83: 's', 68: 'd', 16: 'shift' };
 const KEYS = Object.keys(Key).map(key => +key);
 
 
 onMounted(() => {
 	window.addEventListener('keydown', e => {
-		if (store.hasInput)
+		if (store.input.hasKey)
 			e.preventDefault();
 
 		if (e.altKey || e.ctrlKey || e.metaKey) return;
 		if (! KEYS.includes(e.keyCode)) return;
 
-		store.inputs[Key[e.keyCode]] = true;
+		store.input.key[Key[e.keyCode]] = true;
 	}, false);
 	window.addEventListener('keyup', e => {
-		if (store.hasInput)
+		if (store.input.hasKey)
 			e.preventDefault();
 
 		if (! KEYS.includes(e.keyCode)) return;
 
-		store.inputs[Key[e.keyCode]] = false;
+		store.input.key[Key[e.keyCode]] = false;
 	}, false);
 	window.addEventListener('beforeunload', e => {
-		if (store.hasInput)
+		if (store.input.hasKey)
 			e.preventDefault();
 	});
 });

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, onMounted } from 'vue';
+import { inject, onBeforeUnmount, onMounted } from 'vue';
 
 import Joystick from '@/components/Joystick.vue';
 
@@ -10,28 +10,38 @@ const Key = { 87: 'w', 65: 'a', 83: 's', 68: 'd', 16: 'shift' };
 const KEYS = Object.keys(Key).map(key => +key);
 
 
+const _onKeyDown = e => {
+	if (store.input.hasKey)
+		e.preventDefault();
+
+	if (e.altKey || e.ctrlKey || e.metaKey) return;
+	if (! KEYS.includes(e.keyCode)) return;
+
+	store.input.key[Key[e.keyCode]] = true;
+};
+const _onKeyUp = e => {
+	if (store.input.hasKey)
+		e.preventDefault();
+
+	if (! KEYS.includes(e.keyCode)) return;
+
+	store.input.key[Key[e.keyCode]] = false;
+};
+const _onBeforeUnload = e => {
+	if (store.input.hasKey)
+		e.preventDefault();
+};
+
+
 onMounted(() => {
-	window.addEventListener('keydown', e => {
-		if (store.input.hasKey)
-			e.preventDefault();
-
-		if (e.altKey || e.ctrlKey || e.metaKey) return;
-		if (! KEYS.includes(e.keyCode)) return;
-
-		store.input.key[Key[e.keyCode]] = true;
-	}, false);
-	window.addEventListener('keyup', e => {
-		if (store.input.hasKey)
-			e.preventDefault();
-
-		if (! KEYS.includes(e.keyCode)) return;
-
-		store.input.key[Key[e.keyCode]] = false;
-	}, false);
-	window.addEventListener('beforeunload', e => {
-		if (store.input.hasKey)
-			e.preventDefault();
-	});
+	window.addEventListener('keydown', _onKeyDown, false);
+	window.addEventListener('keyup', _onKeyUp, false);
+	window.addEventListener('beforeunload', _onBeforeUnload);
+});
+onBeforeUnmount(() => {
+	window.removeEventListener('keydown', _onKeyDown, false);
+	window.removeEventListener('keyup', _onKeyUp, false);
+	window.removeEventListener('beforeunload', _onBeforeUnload);
 });
 </script>
 

--- a/src/components/Dev.vue
+++ b/src/components/Dev.vue
@@ -13,9 +13,19 @@ const displayPxSize = computed(() => (store.display
 	: 'none'
 ));
 
-const inputs = computed(() => JSON.stringify(
-	Object.keys(store.inputs).filter(key => store.inputs[key]), null, 1,
-).replace(/["\n]/g, '').replace(/\]/, ' ]').toUpperCase());
+const getInput = hash => Object.keys(hash).filter(key => hash[key]);
+const input = computed(
+	() => {
+		const input = [
+			...getInput(store.input.key),
+			...getInput(store.input.virtual).map(input => `VIRTUAL_${input}`),
+		]
+		return JSON.stringify(input, null, 1)
+			.replace(/["\n]/g, '')
+			.replace(/\]/, ' ]')
+			.toUpperCase();
+	},
+);
 const isDevHidden = ref(false);
 const deci = n => (
 	(n === -0)
@@ -76,8 +86,10 @@ const deci = n => (
 				<dl class="dl-cols  ms-2 mb-0">
 					<dt>avatar style:</dt>
 					<dd><output>{{ store.avatarStyle }}</output></dd>
+					<dt>control type:</dt>
+					<dd><output>{{ store.controlType }}</output></dd>
 					<dt>inputs:</dt>
-					<dd><output>{{ inputs }}</output></dd>
+					<dd><output>{{ input }}</output></dd>
 					<dt>position:</dt>
 					<dd><output>(x: {{ Math.round(store.x) }}, y: {{ Math.round(store.y) }})</output></dd>
 					<dt>speed:</dt>

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -142,9 +142,13 @@ window.$game = { clock, store, sprite, hitbox };
 watch(() => store.isPaused, () => store.isPaused && draw());
 
 
+const _onBlur = () => isWindowFocussed = false;
+const _onFocus = () => isWindowFocussed = true;
+
+
 onMounted(() => {
-	window.addEventListener('blur', () => isWindowFocussed = false);
-	window.addEventListener('focus', () => isWindowFocussed = true);
+	window.addEventListener('blur', _onBlur);
+	window.addEventListener('focus', _onFocus);
 
 	store.displayTo(document.getElementById('game-display'));
 
@@ -155,6 +159,9 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+	window.removeEventListener('blur', _onBlur);
+	window.removeEventListener('focus', _onFocus);
+
 	delete window.$game;
 
 	store.reset();

--- a/src/components/Joystick.vue
+++ b/src/components/Joystick.vue
@@ -6,8 +6,6 @@ const store = inject('store');
 
 const $handle = ref(null);
 
-const controlling = ref(false);
-
 let pointerX = 0;
 let pointerY = 0;
 
@@ -19,7 +17,7 @@ const position = computed(() => ({
 
 
 function controlStart(e) {
-	controlling.value = true;
+	store.input.virtual.stick = true;
 
 	pointerX = e.x;
 	pointerY = e.y;
@@ -27,7 +25,8 @@ function controlStart(e) {
 	$handle.value.setPointerCapture(e.pointerId);
 }
 function controlMove(e) {
-	if (! controlling.value) return;
+	if (! store.input.virtual.stick) return;
+
 
 	store.throttleX = (e.x - pointerX) / 100;
 	store.throttleY = (e.y - pointerY) / 100;
@@ -38,13 +37,13 @@ function controlMove(e) {
 		controlEnd();
 }
 function controlEnd(e) {
-	controlling.value = false;
-
-	store.throttleX = pointerX = 0;
-	store.throttleY = pointerY = 0;
-
 	if (e && $handle.value.hasPointerCapture(e.pointerId))
 		$handle.value.releasePointerCapture(e.pointerId);
+
+	store.input.virtual.stick = false;
+
+	store.throttleX = pointerX = position.x = 0;
+	store.throttleY = pointerY = position.y = 0;
 }
 </script>
 

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -1,0 +1,70 @@
+<script setup>
+import { ref } from 'vue';
+
+
+const $dialog = ref(null);
+const showing = ref(false);
+
+
+function close() { showing.value = false; }
+function show() { showing.value = true; }
+
+
+defineExpose({
+	close,
+	show,
+});
+</script>
+
+
+
+<template>
+	<Transition
+		@before-enter="$emit('show');$dialog.showModal();"
+		@after-enter="$emit('shown');"
+		@before-leave="$emit('close');"
+		@after-leave="$dialog.close();$emit('closed');"
+	>
+		<dialog
+			class="modal"
+			@click="close"
+			ref="$dialog"
+			v-show="showing"
+		>
+			<form
+				method="dialog"
+				class="modal-content"
+				@click.stop
+			>
+				<slot></slot>
+			</form>
+		</dialog>
+	</Transition>
+</template>
+
+
+
+<style>
+.modal:modal {
+	position: fixed;
+	height: fit-content;
+	width: fit-content;
+	background: none;
+	border: none;
+	overflow-x: auto;
+	overflow-y: auto;
+}
+.modal[open] {
+	display: block;
+}
+
+.v-enter-active,
+.v-leave-active {
+	transition: opacity 0.2s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+	opacity: 0;
+}
+</style>

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -110,14 +110,18 @@ const store = reactive({
 watchEffect(() => window.localStorage.setItem('color', store.color));
 watchEffect(() => window.localStorage.setItem('avatar', store.avatarStyle));
 watchEffect(() => {
-	if (store.isPaused) return;
+	if (store.isPaused
+	||  ! [ ControlType.KEYS, ControlType.NONE ].includes(store.controlType))
+		return;
 
 	const { d, a, R, L } = store.input.key;
 
 	store.throttleX = d - a; // note: coerced from booleans
 });
 watchEffect(() => {
-	if (store.isPaused) return;
+	if (store.isPaused
+	||  ! [ ControlType.KEYS, ControlType.NONE ].includes(store.controlType))
+		return;
 
 	const { w, s, U, D } = store.input.key;
 

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -4,6 +4,13 @@ import { computed, reactive, ref, watchEffect } from 'vue';
 
 export class StoreTypeError extends TypeError {}
 
+export const ControlType = Object.freeze({
+	KEYS: 'KEYS',
+	NONE: 'NONE',
+	VIRTUAL: 'VIRTUAL',
+	__proto__: null,
+});
+
 
 // PRIVATE PROPERTIES
 const throttle = computed(() => (
@@ -27,6 +34,7 @@ const store = reactive({
 	// PUBLIC PROPERTIES
 	avatarStyle: window.localStorage.getItem('avatar') || 'bug',
 	color: window.localStorage.getItem('color') || '#55aadd',
+	controlType: ControlType.NONE,
 	/** @var {?CanvasRenderingContext2D} */
 	display: null,
 	/** @readonly */
@@ -121,6 +129,16 @@ watchEffect(() => {
 
 	// see https://stackoverflow.com/questions/15994194/how-to-convert-x-y-coordinates-to-an-angle
 	facing.value = Math.atan2(store.throttleX, -store.throttleY); // -Y because canvas Y-axis increases downward as opposed to upward
+});
+watchEffect(() => {
+	if (! store.input.hasAny)
+		return store.controlType = ControlType.NONE;
+
+	if (store.input.hasVirtual)
+		return store.controlType = ControlType.VIRTUAL;
+
+	if (store.input.hasKey)
+		return store.controlType = ControlType.KEYS;
 });
 
 

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -17,7 +17,11 @@ const throttle = computed(() => (
 	store.isPaused ? 0 : Math.sqrt(store.throttleX ** 2 + store.throttleY ** 2)
 ));
 const normalFactor = computed(() => (
-	(store.isPaused || throttle.value <= 1) ? 1 : (1 / throttle.value)
+	(
+		(store.isPaused || throttle.value <= 1) ? 1 : (1 / throttle.value)
+	) * (
+		store.slow ? .4 : 1
+	)
 ));
 const facing = ref(0);
 
@@ -67,6 +71,10 @@ const store = reactive({
 	},
 	isPaused: false,
 	sensitivity: 1,
+	/** @readonly */
+	slow: computed(() => (
+		store.controlType === ControlType.KEYS && store.input.key.shift
+	)),
 	/** @readonly */
 	speed: computed(() => normalize(throttle.value)),
 	/** @readonly */

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -17,6 +17,10 @@ const facing = ref(0);
 
 // PRIVATE METHODS
 const normalize = n => n * normalFactor.value;
+const any = (hash, keys) => Array.isArray(keys)
+	? keys.some(key => Object.hasOwn(hash, key) && hash[key])
+	: Object.values(hash).some(value => value);
+
 
 
 const store = reactive({
@@ -38,12 +42,20 @@ const store = reactive({
 	/** @readonly */
 	facing: computed(() => facing.value),
 	/** @readonly */
-	hasInput: computed(() => Object.values(store.inputs).some(value => value)),
-	inputs: {
-		w: false,
-		a: false,
-		s: false,
-		d: false,
+	input: {
+		hasAny: computed(() => store.input.hasKey || store.input.hasVirtual),
+		hasKey: computed(() => any(store.input.key, 'wasd'.split(''))),
+		hasVirtual: computed(() => any(store.input.virtual)),
+		key: {
+			w: false,
+			a: false,
+			s: false,
+			d: false,
+			shift: false,
+		},
+		virtual: {
+			stick: false,
+		},
 	},
 	isPaused: false,
 	sensitivity: 1,
@@ -92,14 +104,14 @@ watchEffect(() => window.localStorage.setItem('avatar', store.avatarStyle));
 watchEffect(() => {
 	if (store.isPaused) return;
 
-	const { d, a, R, L } = store.inputs;
+	const { d, a, R, L } = store.input.key;
 
 	store.throttleX = d - a; // note: coerced from booleans
 });
 watchEffect(() => {
 	if (store.isPaused) return;
 
-	const { w, s, U, D } = store.inputs;
+	const { w, s, U, D } = store.input.key;
 
 	store.throttleY = s - w; // note: coerced from booleans
 });


### PR DESCRIPTION
This adds "slow mode" for keyboard control by holding [Shift] while moving.  Holding shift won't affect the virtual stick control.

Additionally, this officially makes the virtual stick input supersede keyboard input.  Previously it mostly was, but it was unreliable, so this makes behaviors more predictable all around.  Also, if you stop using the virtual stick and you have keys pressed, the bug will follow the incoming commands, which is just a nice detail.

https://github.com/calvinjuarez/browser-game/assets/2146819/661d44bc-71c8-419d-b6a3-33bb948ff7d6